### PR TITLE
Custom Mounts and Optional Secret

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 tag = False
 message = Bump version: pihole-synchronized helm chart {current_version} → {new_version}

--- a/.github/workflows/package-helm-chart.yml
+++ b/.github/workflows/package-helm-chart.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-repo:
     env:
-      version: 0.2.0
+      version: 0.3.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See `pihole-synchronized/values.yaml` for all values, the following table lists 
 
 | Variable | Default | Explaination |
 | -- | -- | -- |
-| piholeAdminPass | password | Change this before deploying to be the password you want used with the web interface. |
+| piholeAdminPass | password | Set this before deploying to be the password you want used with the web interface, or leave empty to provide the password as an environmental variable or in a volume mount. |
 | replicaCount | 2 | Number of pihole pods to deploy |
 | image | multi-value | Details for the pihole image to deploy. |
 | initSecurityContext | multi-value | user and group to execute the init and sync containers under, change with caution as it may block startup of non-primary pods |
@@ -41,6 +41,8 @@ See `pihole-synchronized/values.yaml` for all values, the following table lists 
 | loadBalancer.ip | 192.168.0.2 | Set to your desired DNS IP |
 | loadBalancer.addressPool | default | Set to the appropriate IP pool for Metallb |
 | environmentalVariables | multi-value | See [Pihole Environmental Values](https://github.com/pi-hole/docker-pi-hole#environment-variables) |
+| volumeMounts | [] | Allows setting a list of custom volume mounts |
+| volumes | [] | Allows setting a list of custom volumes |
 | customDomains | Empty | Provide contents of `/etc/pihole/custom.list` to configure local domains |
 | ingress.host | pihole.example.com | Configure host for Ingress to configure |
 | ingress.useTls | true | Enable TLS - strongly encouraged even for local networks |

--- a/pihole-synchronized/Chart.yaml
+++ b/pihole-synchronized/Chart.yaml
@@ -3,6 +3,6 @@ name: pihole-synchronized
 description: Deploys a Pihole StatefulSet with replication between pods
 
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "2022.02.1"
 icon: https://wp-cdn.pi-hole.net/wp-content/uploads/2018/12/pihole-text-logo-white.png

--- a/pihole-synchronized/templates/secret.yaml
+++ b/pihole-synchronized/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.piholeAdminPass }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 type: Opaque
 stringData:
     webpassword: {{ .Values.piholeAdminPass }}
+{{- end }}

--- a/pihole-synchronized/templates/statefulset.yaml
+++ b/pihole-synchronized/templates/statefulset.yaml
@@ -69,9 +69,14 @@ spec:
             - name: custom-lists
               mountPath: /etc/pihole/custom.list
               subPath: custom.list
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.piholeAdminPass }}
             - name: webpassword
               mountPath: /mnt/webpassword
               subPath: webpassword
+            {{- end }}
 
       restartPolicy: Always
       volumes:
@@ -84,12 +89,17 @@ spec:
             items:
             - key: custom.list
               path: custom.list
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.piholeAdminPass }}
         - name: webpassword
           secret:
             secretName: {{ include "pihole-synchronized.fullname" . }}-secret
             items:
             - key: webpassword
               path: webpassword
+        {{- end }}
         - name: db-backup
           persistentVolumeClaim:
             claimName:  {{ include "pihole-synchronized.fullname" . }}-db-backup

--- a/pihole-synchronized/values.yaml
+++ b/pihole-synchronized/values.yaml
@@ -2,8 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Change me!
-piholeAdminPass: password
+# Can set here to add a secret with the password
+# Alternatively can be set in the environment, or mounted with volumes and volumeMounts
+piholeAdminPass: ""
 
 # Number of pihole replicas to deploy
 replicaCount: 2
@@ -90,6 +91,10 @@ environmentalVariables:
   FTLCONF_REPLY_ADDR4: 192.168.0.2 # Should match loadBalancer ip
   FTLCONF_MOZILLA_CANARY: "true"
   WEBPASSWORD_FILE: /mnt/webpassword
+
+# Mount in a volume(s)
+volumeMounts: []
+volumes: []
 
 # Populates /etc/pihole/custom.list
 customDomains: ""


### PR DESCRIPTION
Allow custom mounts with `volumes` and `volumeMounts`, enabling piholeAdminPass  to be optional (secret is not created if piholeAdminPass is not set)